### PR TITLE
Bump Guzzle Version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=5.5.0",
         "lib-curl": "*",
-        "guzzlehttp/guzzle": "~7.0"
+        "guzzlehttp/guzzle": "^7.0.1"
     },
 
     "require-dev": {


### PR DESCRIPTION
Bump Guzzle Version from ~7.0 to ^7.0.1 for Laravel 8+ Support